### PR TITLE
Add _totalMinted Function

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -115,12 +115,24 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
 
     /**
      * @dev See {IERC721Enumerable-totalSupply}.
+     * @dev Burned tokens are calculated here, use _totalMinted() if you want to count just minted tokens.
      */
     function totalSupply() public view returns (uint256) {
         // Counter underflow is impossible as _burnCounter cannot be incremented
         // more than _currentIndex - _startTokenId() times
         unchecked {
             return _currentIndex - _burnCounter - _startTokenId();    
+        }
+    }
+
+    /**
+     * Returns the total amount of tokens minted in the contract.
+     */
+    function _totalMinted() internal view returns (uint256) {
+        // Counter underflow is impossible as _currentIndex does not decrement,
+        // and it is initialized to _startTokenId()
+        unchecked {
+            return _currentIndex - _startTokenId();
         }
     }
 

--- a/contracts/mocks/ERC721ABurnableMock.sol
+++ b/contracts/mocks/ERC721ABurnableMock.sol
@@ -19,4 +19,8 @@ contract ERC721ABurnableMock is ERC721A, ERC721ABurnable {
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
         return _ownerships[index];
     }
+
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
 }

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -12,6 +12,10 @@ contract ERC721AMock is ERC721A {
         return _numberMinted(owner);
     }
 
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     function getAux(address owner) public view returns (uint64) {
         return _getAux(owner);
     }

--- a/contracts/mocks/ERC721AStartOneMock.sol
+++ b/contracts/mocks/ERC721AStartOneMock.sol
@@ -16,6 +16,10 @@ contract ERC721AStartOneMock is ERC721A {
         return _numberMinted(owner);
     }
 
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
     function getAux(address owner) public view returns (uint64) {
         return _getAux(owner);
     }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -18,6 +18,11 @@ describe('ERC721A', function () {
       const supply = await this.erc721a.totalSupply();
       expect(supply).to.equal(0);
     });
+
+    it('has 0 totalMinted', async function () {
+      const totalMinted = await this.erc721a.totalMinted();
+      expect(totalMinted).to.equal(0);
+    });
   });
 
   context('with minted tokens', async function () {
@@ -65,6 +70,13 @@ describe('ERC721A', function () {
         expect(await this.erc721a.numberMinted(this.addr1.address)).to.equal('1');
         expect(await this.erc721a.numberMinted(this.addr2.address)).to.equal('2');
         expect(await this.erc721a.numberMinted(this.addr3.address)).to.equal('3');
+      });
+    });
+
+    context('_totalMinted', async function () {
+      it('has 6 totalMinted', async function () {
+        const totalMinted = await this.erc721a.totalMinted();
+        expect(totalMinted).to.equal('6');
       });
     });
 

--- a/test/ERC721AStartOne.test.js
+++ b/test/ERC721AStartOne.test.js
@@ -18,6 +18,11 @@ describe('ERC721AStartOne', function () {
       const supply = await this.erc721a.totalSupply();
       expect(supply).to.equal(0);
     });
+
+    it('has 0 totalMinted', async function () {
+      const minted = await this.erc721a.totalMinted();
+      expect(minted).to.equal(0);
+    });
   });
 
   context('with minted tokens', async function () {
@@ -67,6 +72,13 @@ describe('ERC721AStartOne', function () {
         expect(await this.erc721a.numberMinted(this.addr1.address)).to.equal('1');
         expect(await this.erc721a.numberMinted(this.addr2.address)).to.equal('2');
         expect(await this.erc721a.numberMinted(this.addr3.address)).to.equal('3');
+      });
+    });
+
+    context('_totalMinted', async function () {
+      it('has 6 totalMinted', async function () {
+        const minted = await this.erc721a.totalMinted();
+        expect(minted).to.equal('6');
       });
     });
 

--- a/test/extensions/ERC721ABurnable.test.js
+++ b/test/extensions/ERC721ABurnable.test.js
@@ -53,6 +53,15 @@ describe('ERC721ABurnable', function () {
     }
   })
 
+  it('does not affect _totalMinted', async function () {
+    const totalMintedBefore = await this.token.totalMinted();
+    expect(totalMintedBefore).to.equal(this.numTestTokens);
+    for (let i = 0; i < 2; ++i) {
+      await this.token.connect(this.addr1).burn(i);
+    }
+    expect(await this.token.totalMinted()).to.equal(totalMintedBefore);
+  });
+
   it('adjusts owners balances', async function () {
     expect(await this.token.balanceOf(this.addr1.address))
       .to.be.equal(this.numTestTokens - 1);


### PR DESCRIPTION
Add `_totalMinted` function, as discussed in #124 

I add tests for these situations:
* For both start token at 0 and 1
    * Before mint must return 0
    * After mint return correct value
* For ERC721ABurnable
    * Burning must not affect return value.

Also, added a comment for `totalSupply()` to encourage using `_totalMinted()` instead (for checking minted counts).